### PR TITLE
Replace showWelcomeScreen parameter with the presentationMode environment variable

### DIFF
--- a/Welcome/Welcome/ContentView.swift
+++ b/Welcome/Welcome/ContentView.swift
@@ -14,9 +14,7 @@ struct ContentView: View {
         Button(action: { self.showWelcomeScreen = true }) {
             Text("Show Welcome screen")
         }
-        .sheet(isPresented: $showWelcomeScreen) {
-            WelcomeScreen(showWelcomeScreen: $showWelcomeScreen)
-        }
+        .sheet(isPresented: $showWelcomeScreen, content: WelcomeScreen.init)
     }
 }
 

--- a/Welcome/Welcome/WelcomeScreen.swift
+++ b/Welcome/Welcome/WelcomeScreen.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct WelcomeScreen: View {
-    @Binding var showWelcomeScreen: Bool
+    @Environment(\.presentationMode) private var presentationMode
     
     var body: some View {
         VStack {
@@ -32,7 +32,7 @@ struct WelcomeScreen: View {
             Spacer()
             Spacer()
             
-            Button(action: { self.showWelcomeScreen = false }) {
+            Button(action: { presentationMode.wrappedValue.dismiss() }) {
                 HStack {
                     Spacer()
                     Text("Continue")
@@ -51,6 +51,6 @@ struct WelcomeScreen: View {
 
 struct WelcomeScreen_Previews: PreviewProvider {
     static var previews: some View {
-        WelcomeScreen(showWelcomeScreen: .constant(true))
+        WelcomeScreen()
     }
 }


### PR DESCRIPTION
Hey @jordansinger,

I've replaced the **showWelcomeScreen** Binding with the new [PresentationMode](https://developer.apple.com/documentation/swiftui/presentationmode) environment variable.

This simplifies the way **WelcomeScreen** is presented.